### PR TITLE
Add support for twitter bootstrap css style , with nested def

### DIFF
--- a/lib/r2.rb
+++ b/lib/r2.rb
@@ -61,20 +61,19 @@ module R2
     def r2(original_css)
       css = minimize(original_css)
 
-      result = css.gsub(/([^\{]+\{[^\}]+\})+?/) do |rule|
-        # break rule into selector|declaration parts
-        parts = rule.match(/([^\{]+)\{([^\}]+)/)
-        selector = parts[1]
-        declarations = parts[2]
-
-        rule_str = selector + '{'
-        declarations.split(/;(?!base64)/).each do |decl|
-          rule_str << declartion_swap(decl)
-        end
-        rule_str << "}"
+      result = css.gsub(/([^\{\}]+[^\}]|[\}])+?/) do |rule|
+				if rule.match(/[\{\}]/)
+					#it is a selector with "{" or a closing "}", insert as it is 
+					rule_str = rule
+				else
+					#It is a decleration	
+					rule_str = ""
+					rule.split(/;(?!base64)/).each do |decl|
+						rule_str << declartion_swap(decl)
+					end
+				end
         rule_str
       end
-
       return result
     end
 


### PR DESCRIPTION
Hello,

I wanted to use your gem for displaying Twitter Bootstrap for RTL (hebrew), and saw that there is no support for the nested @media declaration, so I tried to add the support , and managed to do it by changing the r2 function and the reg-ex.

I tested it in my app with bootstrap rtl, and it works great, I did not manage to execute tests (I am still learning ) 
Hope you will use it in your gem.
please let me know if you find any issues .

Thanks,

Haim Lankry

If we have the string : " h1 {padding:3px;} @media (size=40){h1 {margin:20px;padding:3px;}} "
The new Regexp is : /([^{}]+[^}]|[}])+?/
we will get the results:

Match 1
h1 {
Match 2
padding:3px;
Match 3
}
Match 4
@media (size=40){
Match 5
h1 {
Match 6
margin:20px;padding:3px;
Match 7
}
Match 8
}
