### PR TITLE
Swapping clear property direction

### DIFF
--- a/lib/r2.rb
+++ b/lib/r2.rb
@@ -54,7 +54,8 @@ module R2
       'box-shadow' => lambda {|obj,val| obj.quad_swap(val) },
       '-webkit-box-shadow' => lambda {|obj,val| obj.quad_swap(val) },
       '-moz-box-shadow' => lambda {|obj,val| obj.quad_swap(val) },
-      'direction'  => lambda {|obj,val| obj.direction_swap(val) }
+      'direction'  => lambda {|obj,val| obj.direction_swap(val) },
+      'clear' => lambda {|obj,val| obj.side_swap(val) }
     }
 
     # Given a String of CSS perform the full directionality change


### PR DESCRIPTION
I'm an engineer on the international team at Twitter, and was assigned to fix a bug involving our new profile pages on the RTL version of the site. Noticed that "clear" wasn't having its direction reversed, so I added it to the list of properties swapped by R2.
