### PR TITLE
Add swap for background-position

### DIFF
--- a/lib/r2.rb
+++ b/lib/r2.rb
@@ -58,7 +58,8 @@ module R2
       '-webkit-box-shadow' => lambda {|obj,val| obj.quad_swap(val) },
       '-moz-box-shadow' => lambda {|obj,val| obj.quad_swap(val) },
       'direction'  => lambda {|obj,val| obj.direction_swap(val) },
-      'clear' => lambda {|obj,val| obj.side_swap(val) }
+      'clear' => lambda {|obj,val| obj.side_swap(val) },
+      'background-position' => lambda {|obj,val| obj.background_position_swap(val) }
     }
 
     # Given a String of CSS perform the full directionality change
@@ -163,6 +164,31 @@ module R2
       else
         val
       end
+    end
+
+    # Given a background-position such as <tt>left center</tt> or <tt>0% 50%</tt> return the opposing value e.g <tt>right center</tt> or <tt>100% 50%</tt>
+    def background_position_swap(val)
+
+      if val =~ /left/
+        val.gsub!('left', 'right')
+      elsif val =~ /right/
+        val.gsub!('right', 'left')
+      end
+
+      points = val.strip.split(/\s+/)
+
+      # If first point is a percentage-value
+      if match = points[0].match(/(\d+)%/)
+        inv = 100 - match[1].to_i # 30% => 70% (100 - x)
+        val = ["#{inv}%", points[1]].compact.join(' ')
+      end
+
+      # If first point is a unit-value
+      if match = points[0].match(/^(\d+[a-z]{2,3})/)
+        val = ["right", match[1], points[1] || "center"].compact.join(' ')
+      end
+
+      val
     end
   end
 

--- a/spec/r2_spec.rb
+++ b/spec/r2_spec.rb
@@ -111,4 +111,68 @@ describe R2 do
       @r2.border_radius_swap("1px 2px").should == "2px 1px"
     end
   end
+
+  context "background_position_swap" do
+
+    context "with a single value" do
+      it "should ignore a named-vertical" do
+        @r2.background_position_swap('top').should == 'top'
+      end
+
+      it "should swap a named-horizontal 'left'" do
+        @r2.background_position_swap('left').should == 'right'
+      end
+
+      it "should swap a named-horizontal 'right'" do
+        @r2.background_position_swap('right').should == 'left'
+      end
+
+      it "should invert a percentage" do
+        @r2.background_position_swap('25%').should == '75%'
+      end
+
+      it "should convert a unit value" do
+        @r2.background_position_swap('25px').should == 'right 25px center'
+      end
+    end
+
+    context "with a pair of values" do
+      # Note that a pair of keywords can be reordered while a combination of
+      # keyword and length or percentage cannot. So ‘center left’ is valid
+      # while ‘50% left’ is not.
+      # See: http://dev.w3.org/csswg/css3-background/#background-position
+
+      it "should swap named-horizontal and ignore named-vertical" do
+        @r2.background_position_swap('right bottom').should == 'left bottom'
+      end
+
+      it "should swap named-horizontal and ignore unit-vertical" do
+        @r2.background_position_swap('left 100px').should == 'right 100px'
+      end
+
+      it "should convert unit-horizontal" do
+        @r2.background_position_swap('100px center').should == 'right 100px center'
+      end
+
+      it "should swap named-horizontal and ignore percentage-vertical" do
+        @r2.background_position_swap('left 0%').should == 'right 0%'
+      end
+
+      it "should invert first percentage-horizontal value in a pair" do
+        @r2.background_position_swap('25% 100%').should == '75% 100%'
+      end
+    end
+
+    context "with a triplet of values" do
+      it "should swap named-horizontal" do
+        @r2.background_position_swap('left 20px center').should == 'right 20px center'
+      end
+    end
+
+    context "with a quad of values" do
+      it "should swap named-horizontal value" do
+        @r2.background_position_swap('bottom 10px left 20px').should == 'bottom 10px right 20px'
+      end
+    end
+  end
 end


### PR DESCRIPTION
This patch adds support for swapping `background-position` values. It cribs from the [original JS version of R2](https://github.com/ded/R2/blob/f690519bd15c138b0031bae961c85c8ebc3e9d83/r2.js#L44) but handles a couple more cases and has more expansive test coverage.

N.B. Position values in `background` properties aren't swapped.
