### PR TITLE
Add homepage to the gemspec

### DIFF
--- a/r2.gemspec
+++ b/r2.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Matt Sanford"]
   s.email       = ["matt@twitter.com"]
-  s.homepage    = ""
+  s.homepage    = "https://github.com/mzsanford/R2rb"
   s.summary     = %q{CSS flipper for right-to-left processing}
   s.description = %q{CSS flipper for right-to-left processing. A Ruby port of https://github.com/ded/r2}
 


### PR DESCRIPTION
Currently, there is no link to the source code from http://rubygems.org/gems/r2. Let's change that.
