### PR TITLE
Bugfix: Convert newlines to spaces instead of removing them

### DIFF
--- a/lib/r2.rb
+++ b/lib/r2.rb
@@ -110,7 +110,7 @@ module R2
       return '' unless css
 
       css.gsub(/\/\*[\s\S]+?\*\//, '').   # comments
-         gsub(/[\n\r]/, '').              # line breaks and carriage returns
+         gsub(/[\n\r]/, ' ').             # line breaks and carriage returns
          gsub(/\s*([:;,\{\}])\s*/, '\1'). # space between selectors, declarations, properties and values
          gsub(/\s+/, ' ').                # replace multiple spaces with single spaces
          gsub(/(\A\s+|\s+\z)/, '')        # leading or trailing spaces

--- a/lib/r2.rb
+++ b/lib/r2.rb
@@ -110,7 +110,7 @@ module R2
       return '' unless css
 
       css.gsub(/\/\*[\s\S]+?\*\//, '').   # comments
-         gsub(/[\n\r]/, ' ').             # line breaks and carriage returns
+         gsub(/[\n\r]+/, ' ').            # line breaks and carriage returns
          gsub(/\s*([:;,\{\}])\s*/, '\1'). # space between selectors, declarations, properties and values
          gsub(/\s+/, ' ').                # replace multiple spaces with single spaces
          gsub(/(\A\s+|\s+\z)/, '')        # leading or trailing spaces

--- a/spec/r2_spec.rb
+++ b/spec/r2_spec.rb
@@ -92,6 +92,21 @@ describe R2::Swapper do
 
       flipped_css.should == expected_result
     end
+
+    it "handles newline correctly" do
+      css =
+       "fieldset[disabled]\n" +
+       "input[type=\"checkbox\"], fieldset[disabled]\n" +
+       ".radio {\n" +
+       "  cursor: not-allowed; }"
+
+      expected =
+        'fieldset[disabled] input[type="checkbox"],' +
+        'fieldset[disabled] .radio' +
+        '{cursor:not-allowed;}'
+
+      r2.r2(css).should == expected
+    end
   end
 
   describe "#declaration_swap" do
@@ -125,12 +140,12 @@ describe R2::Swapper do
       r2.minimize("/* comment */foo").should == "foo"
     end
 
-    it "should remove newlines" do
-      r2.minimize("foo\nbar").should == "foobar"
+    it "should convert newlines to spaces" do
+      r2.minimize("foo\nbar").should == "foo bar"
     end
 
-    it "should remove carriage returns" do
-      r2.minimize("foo\rbar").should == "foobar"
+    it "should convert carriage returns to spaces" do
+      r2.minimize("foo\rbar").should == "foo bar"
     end
 
     it "should collapse multiple spaces into one" do

--- a/spec/r2_spec.rb
+++ b/spec/r2_spec.rb
@@ -144,6 +144,10 @@ describe R2::Swapper do
       r2.minimize("foo\nbar").should == "foo bar"
     end
 
+    it "should convert multiple newlines to a space" do
+      r2.minimize("foo\n\n\nbar").should == "foo bar"
+    end
+
     it "should convert carriage returns to spaces" do
       r2.minimize("foo\rbar").should == "foo bar"
     end


### PR DESCRIPTION
This fixes the following scenario:

``` css
.row
.span3 {
  color: red;
}
```

becomes:

``` css
.row.span3{color:red};
```

when it should become:

``` css
.row .span3{color:red};
```
